### PR TITLE
feat(address): extract address & mapsUrl into a separate Address model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -234,8 +234,8 @@ model Address {
   updatedAt DateTime @updatedAt
 
   fullAddress   String // The full address text, including province and city
-  province      String
-  city          String
+  province      String // Province
+  city          String // Kota/Kabupaten
   googleMapsURL String? // https://goo.gl/maps/1xABCDEF123456
 
   // Geolocation, for future purposes when we need to display an embedded map
@@ -244,6 +244,8 @@ model Address {
 
   placeId String @unique
   place   Place  @relation("PlaceAddress", fields: [placeId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@index([placeId])
 }
 
 // -----------------------------------------------------------------------------

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -186,11 +186,9 @@ model Place {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  slug        String  @unique
+  slug        String @unique
   name        String
-  description String  @db.Text
-  mapsUrl     String?
-  address     String?
+  description String @db.Text
 
   isVerified   Boolean   @default(false)
   verifiedAt   DateTime?
@@ -200,9 +198,10 @@ model Place {
   isPublished Boolean   @default(false)
   publishedAt DateTime?
 
-  userId String
-  user   User         @relation("UserPlaces", fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
-  images PlaceImage[] @relation("PlaceImages")
+  userId  String
+  user    User         @relation("UserPlaces", fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  images  PlaceImage[] @relation("PlaceImages")
+  address Address?     @relation("PlaceAddress")
 
   @@index([userId])
   @@index([verifiedById])
@@ -223,6 +222,28 @@ model PlaceImage {
 
   @@index([userId])
   @@index([placeId])
+}
+
+// -----------------------------------------------------------------------------
+// Address
+// -----------------------------------------------------------------------------
+
+model Address {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  fullAddress   String // The full address text, including province and city
+  province      String
+  city          String
+  googleMapsURL String? // https://goo.gl/maps/1xABCDEF123456
+
+  // Geolocation, for future purposes when we need to display an embedded map
+  latitude  Decimal? // -90 to 90, Example: -6.1234567
+  longitude Decimal? // -180 to 180, Example: 106.1234567
+
+  placeId String @unique
+  place   Place  @relation("PlaceAddress", fields: [placeId], references: [id], onUpdate: Cascade, onDelete: Cascade)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2

## What kind of change does this PR introduce?

Extract `address` & `mapsUrl` into a separate Address model.

## What is the current behavior?

The `address` & `mapsUrl` fields are a part of `Place` model.

## What is the new behavior?

All address-related fields are extracted to a new `Address` entity with a minimum amount of fields required for displaying and filtering.

## Additional context

This is how the schema differences look like on PlanetScale:

![image](https://user-images.githubusercontent.com/6315466/233237883-2308cc4c-7171-4865-bdbd-1fe79d0ee10d.png)

