### PR TITLE
feat: upload QR code image

### DIFF
--- a/app/models/place.server.ts
+++ b/app/models/place.server.ts
@@ -30,6 +30,7 @@ export const query = {
           select: model.user.fields.public,
         },
         images: true,
+        qrCode: true,
       },
     });
   },
@@ -48,6 +49,7 @@ export const query = {
       include: {
         user: { select: model.user.fields.public },
         images: true,
+        qrCode: true,
       },
     });
   },

--- a/app/routes/places.$placeSlug._index.tsx
+++ b/app/routes/places.$placeSlug._index.tsx
@@ -134,7 +134,7 @@ export default function Route() {
           ))}
 
           <Image
-            src={`/assets/images/contoh-qr-code.png`}
+            src={place.qrCode?.url}
             alt={`QR code donasi ke ${place.name}`}
             className="h-64 max-w-sm"
           />

--- a/app/routes/user.places.new._index.tsx
+++ b/app/routes/user.places.new._index.tsx
@@ -58,6 +58,12 @@ export async function action({ request }: ActionArgs) {
         // @ts-ignore
         url: submission.value.imageUrl,
       },
+      placeQRCode: {
+        // FIXME: Either always require image or allow creating places without image
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        url: submission.value.qrCodeUrl,
+      },
     });
     if (!newPlace) {
       return badRequest(submission);
@@ -76,6 +82,7 @@ export default function Route() {
 
   const { UPLOADCARE_PUBLIC_KEY } = useLoaderData<typeof loader>();
   const [imageUrl, setImageUrl] = useState("");
+  const [qrCodeUrl, setQRCodeUrl] = useState("");
 
   const id = useId();
   const [form, { name, description }] = useForm<z.infer<typeof schemaPlaceNew>>(
@@ -92,6 +99,10 @@ export default function Route() {
 
   const handleChangePlaceImage = (file: FileInfo) => {
     setImageUrl(file.cdnUrl ?? "");
+  };
+
+  const handleChangeQrCodeUrl = (file: FileInfo) => {
+    setQRCodeUrl(file.cdnUrl ?? "");
   };
 
   return (
@@ -139,30 +150,56 @@ export default function Route() {
             <p>Terdapat masalah untuk mengunggah foto masjid</p>
           )}
           {UPLOADCARE_PUBLIC_KEY && (
-            <div>
-              <label hidden htmlFor="imageUrl">
-                Foto masjid:
-              </label>
-              <input
-                type="hidden"
-                id="imageUrl"
-                name="imageUrl"
-                value={imageUrl}
-                readOnly
-              />
-              <label htmlFor="file">Unggah foto masjid:</label>{" "}
-              <UploadcareWidget
-                publicKey={UPLOADCARE_PUBLIC_KEY}
-                tabs="file camera url"
-                previewStep
-                effects="crop, sharp, enhance"
-                customTabs={{ preview: uploadcareTabEffects }}
-                onChange={handleChangePlaceImage}
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                id="file"
-              />
-            </div>
+            <>
+              <div className="space-y-1">
+                <label hidden htmlFor="imageUrl">
+                  Foto masjid:
+                </label>
+                <input
+                  type="hidden"
+                  id="imageUrl"
+                  name="imageUrl"
+                  value={imageUrl}
+                  readOnly
+                />
+                <label htmlFor="file">Unggah foto masjid:</label>{" "}
+                <UploadcareWidget
+                  publicKey={UPLOADCARE_PUBLIC_KEY}
+                  tabs="file camera url"
+                  previewStep
+                  effects="crop, sharp, enhance"
+                  customTabs={{ preview: uploadcareTabEffects }}
+                  onChange={handleChangePlaceImage}
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore
+                  id="file"
+                />
+              </div>
+              <div className="space-y-1">
+                <label hidden htmlFor="qrCodeUrl">
+                  Foto QR Code infaq:
+                </label>
+                <input
+                  type="hidden"
+                  id="qrCodeUrl"
+                  name="qrCodeUrl"
+                  value={qrCodeUrl}
+                  readOnly
+                />
+                <label htmlFor="qrCodeFile">Unggah foto QR Code infaq:</label>{" "}
+                <UploadcareWidget
+                  publicKey={UPLOADCARE_PUBLIC_KEY}
+                  tabs="file camera url"
+                  previewStep
+                  effects="crop, sharp, enhance"
+                  customTabs={{ preview: uploadcareTabEffects }}
+                  onChange={handleChangeQrCodeUrl}
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore
+                  id="qrCodeFile"
+                />
+              </div>
+            </>
           )}
 
           <div className="queue-center">

--- a/app/routes/user.places.new._index.tsx
+++ b/app/routes/user.places.new._index.tsx
@@ -5,7 +5,8 @@ import { useActionData, useLoaderData, useNavigation } from "@remix-run/react";
 import { useId, useState } from "react";
 import { badRequest, serverError } from "remix-utils";
 
-import { FileInfo, Widget as UploadcareWidget } from "@uploadcare/react-widget";
+import type { FileInfo } from "@uploadcare/react-widget";
+import { Widget as UploadcareWidget } from "@uploadcare/react-widget";
 import uploadcareTabEffects from "uploadcare-widget-tab-effects/react-en";
 
 import {
@@ -52,6 +53,9 @@ export async function action({ request }: ActionArgs) {
         description: submission.value.description,
       },
       placeImage: {
+        // FIXME: Either always require image or allow creating places without image
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         url: submission.value.imageUrl,
       },
     });

--- a/app/schemas/place.ts
+++ b/app/schemas/place.ts
@@ -8,6 +8,7 @@ export const schemaPlaceNew = z.object({
     .max(5000, "Deskripsi max 5000 karakter"),
   // TODO: handle multiple images
   imageUrl: z.string().optional(),
+  qrCodeUrl: z.string().optional(),
 });
 
 export const schemaPlaceUpdate = z

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "postinstall": "nr prisma:push",
     "dev": "remix dev",
     "dev-hmr": "run-p dev-hmr:*",
     "dev-hmr:remix": "cross-env NODE_ENV=development USE_HMR=true remix dev",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   places         Place[]            @relation("UserPlaces")
   verifiedPlaces Place[]            @relation("UserPlacesVerifications")
   placeImages    PlaceImage[]       @relation("UserPlaceImages")
+  placeQRCodes   PlaceQRCode[]      @relation("UserPlaceQRCodes")
 
   @@index([roleId])
   @@index([profileId])
@@ -201,6 +202,7 @@ model Place {
   userId  String
   user    User         @relation("UserPlaces", fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   images  PlaceImage[] @relation("PlaceImages")
+  qrCode  PlaceQRCode? @relation("PlaceQRCode")
   address Address?     @relation("PlaceAddress")
 
   @@index([userId])
@@ -219,6 +221,23 @@ model PlaceImage {
   placeId String
   user    User   @relation("UserPlaceImages", fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
   place   Place  @relation("PlaceImages", fields: [placeId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+
+  @@index([userId])
+  @@index([placeId])
+}
+
+model PlaceQRCode {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  url      String
+  filePath String?
+
+  userId  String
+  placeId String @unique
+  user    User   @relation("UserPlaceQRCodes", fields: [userId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  place   Place  @relation("PlaceQRCode", fields: [placeId], references: [id], onUpdate: Cascade, onDelete: Cascade)
 
   @@index([userId])
   @@index([placeId])


### PR DESCRIPTION
Closes #25

## What kind of change does this PR introduce?

- [x] Add QR code entity to the schema
  - [x] Accidentally push the database schema to staging (because [running `pnpm i` command automatically perform `prisma db push`](https://app.warp.dev/block/cf9otHzTwznBCbL2dAJamA))
- [x] Upload QR code in the creation page
- [x] Display QR code in the view page (instead of the hardcoded one)

## What is the new behavior?

### New schema

![image](https://user-images.githubusercontent.com/6315466/233509937-d09dfc7f-efe0-44cb-8aaa-01fbd3590bd4.png)

### Creation form
![image](https://user-images.githubusercontent.com/6315466/233509520-fbb485ba-210d-42e5-8aeb-9db669fa5e5f.png)

### View
<img width="1427" alt="Screenshot 2023-04-21 at 07 50 13" src="https://user-images.githubusercontent.com/6315466/233509593-17fa1ddd-1a8b-4938-8d83-3ac90aaf47d1.png">